### PR TITLE
Added Czech (cs_CZ) locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ const (
     LocaleFrLU = "fr_LU" // French (Luxembourg)
     LocaleFrLU = "fr_MQ" // French (Martinique)
     LocaleFrLU = "fr_GF" // French (French Guiana)
+    LocaleCsCZ = "cs_CZ" // Czech (Czech Republic)
 )
 ```
 

--- a/default_formats.go
+++ b/default_formats.go
@@ -190,6 +190,12 @@ const (
 	DefaultFormatElGRMedium   = "2 Ιαν 2006"
 	DefaultFormatElGRShort    = "02/01/06"
 	DefaultFormatElGRDateTime = "02/01/06 15:04"
+
+	DefaultFormatCsCZFull     = "Monday, 2. January 2006" // English (United Kingdom)
+	DefaultFormatCsCZLong     = "2. January 2006"
+	DefaultFormatCsCZMedium   = "02 Jan 2006"
+	DefaultFormatCsCZShort    = "02.01.2006"
+	DefaultFormatCsCZDateTime = "02/01/2006 15:04"
 )
 
 // 'Full' date formats for all supported locales
@@ -225,6 +231,7 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleZhHK: DefaultFormatZhHKFull,
 	LocaleJaJP: DefaultFormatJaJPFull,
 	LocaleElGR: DefaultFormatElGRFull,
+	LocaleCsCZ: DefaultFormatCsCZFull,
 }
 
 // 'Long' date formats for all supported locales
@@ -260,6 +267,7 @@ var LongFormatsByLocale = map[Locale]string{
 	LocaleZhHK: DefaultFormatZhHKLong,
 	LocaleJaJP: DefaultFormatJaJPLong,
 	LocaleElGR: DefaultFormatElGRLong,
+	LocaleCsCZ: DefaultFormatCsCZLong,
 }
 
 // 'Medium' date formats for all supported locales
@@ -295,6 +303,7 @@ var MediumFormatsByLocale = map[Locale]string{
 	LocaleZhHK: DefaultFormatZhHKMedium,
 	LocaleJaJP: DefaultFormatJaJPMedium,
 	LocaleElGR: DefaultFormatElGRMedium,
+	LocaleCsCZ: DefaultFormatCsCZMedium,
 }
 
 // 'Short' date formats for all supported locales
@@ -330,6 +339,7 @@ var ShortFormatsByLocale = map[Locale]string{
 	LocaleZhHK: DefaultFormatZhHKShort,
 	LocaleJaJP: DefaultFormatJaJPShort,
 	LocaleElGR: DefaultFormatElGRShort,
+	LocaleCsCZ: DefaultFormatCsCZShort,
 }
 
 // 'DateTime' date formats for all supported locales
@@ -365,4 +375,5 @@ var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleZhHK: DefaultFormatZhHKDateTime,
 	LocaleJaJP: DefaultFormatJaJPDateTime,
 	LocaleElGR: DefaultFormatElGRDateTime,
+	LocaleCsCZ: DefaultFormatCsCZDateTime,
 }

--- a/locale.go
+++ b/locale.go
@@ -38,6 +38,7 @@ const (
 	LocaleFrLU = "fr_LU" // French (Luxembourg)
 	LocaleFrMQ = "fr_MQ" // French (Martinique)
 	LocaleFrGF = "fr_GF" // French (French Guiana)
+	LocaleCsCZ = "cs_CZ" // Czech (Czech Republic)
 )
 
 // ListLocales returns all locales supported by the package.
@@ -75,5 +76,6 @@ func ListLocales() []Locale {
 		LocaleFrLU,
 		LocaleFrMQ,
 		LocaleFrGF,
+		LocaleCsCZ,
 	}
 }

--- a/monday.go
+++ b/monday.go
@@ -42,6 +42,7 @@ var internalFormatFuncs = map[Locale]internalFormatFunc{
 	LocaleJaJP: createCommonFormatFunc(LocaleJaJP),
 	LocaleElGR: createCommonFormatFuncWithGenitive(LocaleElGR),
 	LocaleIdID: createCommonFormatFunc(LocaleIdID),
+	LocaleCsCZ: createCommonFormatFunc(LocaleCsCZ),
 }
 
 // internalParseFunc is a preprocessor for default time.ParseInLocation func
@@ -81,6 +82,7 @@ var internalParseFuncs = map[Locale]internalParseFunc{
 	LocaleJaJP: parseFuncJaCommon(LocaleJaJP),
 	LocaleElGR: createCommonParsetFuncWithGenitive(LocaleElGR),
 	LocaleIdID: createCommonParseFunc(LocaleIdID),
+	LocaleCsCZ: createCommonParseFunc(LocaleCsCZ),
 }
 
 var knownDaysShort = map[Locale]map[string]string{}           // Mapping for 'Format', days of week, short form
@@ -312,6 +314,14 @@ func fillKnownWords() {
 	fillKnownDaysShort(shortDayNamesIdID, LocaleIdID)
 	fillKnownMonthsLong(longMonthNamesIdID, LocaleIdID)
 	fillKnownMonthsShort(shortMonthNamesIdID, LocaleIdID)
+
+	// Cs_CZ: Czech (Czech Republic)
+	fillKnownDaysLong(longDayNamesCsCZ, LocaleCsCZ)
+	fillKnownDaysShort(shortDayNamesCsCZ, LocaleCsCZ)
+	fillKnownMonthsLong(longMonthNamesCsCZ, LocaleCsCZ)
+	fillKnownMonthsShort(shortMonthNamesCsCZ, LocaleCsCZ)
+	fillKnownMonthsGenitiveLong(longMonthNamesGenitiveCsCZ, LocaleCsCZ)
+	fillKnownMonthsGenitiveShort(shortMonthNamesGenitiveCsCZ, LocaleCsCZ)
 }
 
 func fill(src map[string]string, dest map[Locale]map[string]string, locale Locale) {

--- a/monday_test.go
+++ b/monday_test.go
@@ -307,6 +307,15 @@ var formatTests = []FormatTest{
 	{LocaleIdID, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2 Jan 2006", "13 Mei 2013"},
 	{LocaleIdID, time.Date(0, 5, 1, 0, 0, 0, 0, time.UTC), "January", "Mei"},
 	{LocaleIdID, time.Date(0, 5, 13, 0, 0, 0, 0, time.UTC), "2 January", "13 Mei"},
+
+	{LocaleCsCZ, time.Date(2013, 9, 3, 0, 0, 0, 0, time.UTC), "Mon Jan 2 2006", "út zář 3 2013"},
+	{LocaleCsCZ, time.Date(2013, 9, 4, 0, 0, 0, 0, time.UTC), "Monday Jan 2 2006", "středa zář 4 2013"},
+	{LocaleCsCZ, time.Date(2013, 10, 3, 0, 0, 0, 0, time.UTC), "Monday January 02 2006", "čtvrtek říjen 03 2013"},
+	{LocaleCsCZ, time.Date(2013, 11, 3, 0, 0, 0, 0, time.UTC), "Monday. 2 January 2006", "neděle. 3 listopad 2013"},
+	{LocaleCsCZ, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2006. 2 January. Monday", "2013. 13 květen. pondělí"},
+	{LocaleCsCZ, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2 Jan 2006", "13 kvě 2013"},
+	{LocaleCsCZ, time.Date(0, 5, 1, 0, 0, 0, 0, time.UTC), "January", "květen"},
+	{LocaleCsCZ, time.Date(0, 5, 13, 0, 0, 0, 0, time.UTC), "2 January", "13 květen"},
 }
 
 func TestFormat(t *testing.T) {


### PR DESCRIPTION
In Czech language there is completely different genitive from previous builds of this project. It applies only and only if dot "." is placed right after day (number). Let me show an example of correct grammar:

"January" = "Leden"; ("Ledna" in genitive)

> 12. ledna 2016
> po 12 leden 2016
> po. 12 leden 2016
> po. 12. ledna 2016

The code returns this instead:

> 12. ledna 2016
> po 12 ledna 2016
> po. 12 ledna 2016
> po. 12. ledna 2016

Nevertheless the genitive is generally omitted on the internet, hence I created a map but localization is loading as createCommonFormatFunc(LocaleCsCZ) without genitive due to its complexity. It does not seem correct to create function solving this issue for single language, therefore the solution, if needed, I leave to end users.
