### PR TITLE
Fix Greek formats

### DIFF
--- a/default_formats.go
+++ b/default_formats.go
@@ -191,9 +191,9 @@ const (
 	DefaultFormatJaJPShort    = "2006/1/2"
 	DefaultFormatJaJPDateTime = "2006/01/02 15:04"
 
-	DefaultFormatElGRFull     = "Δευτέρα, 2 Ιανουαρίου 2006" // Greek (Greece)
-	DefaultFormatElGRLong     = "2 Ιανουαρίου 2006"
-	DefaultFormatElGRMedium   = "2 Ιαν 2006"
+	DefaultFormatElGRFull     = "Monday, 2 January 2006" // Greek (Greece)
+	DefaultFormatElGRLong     = "2 January 2006"
+	DefaultFormatElGRMedium   = "2 Jan 2006"
 	DefaultFormatElGRShort    = "02/01/06"
 	DefaultFormatElGRDateTime = "02/01/06 15:04"
 


### PR DESCRIPTION
Previously, **all** dates using the Greek default formats would render as _Ιαν / Ιανουαρίου_ (Jan / January). This fixes that.