### PR TITLE
Improve monday.Format() performance by using strings.Builder

### DIFF
--- a/monday.go
+++ b/monday.go
@@ -342,7 +342,7 @@ func fill(src map[string]string, dest map[Locale]map[string]string, locale Local
 	loc, ok := dest[locale]
 
 	if !ok {
-		loc = make(map[string]string)
+		loc = make(map[string]string, len(src))
 		dest[locale] = loc
 	}
 
@@ -355,7 +355,7 @@ func fillReverse(src map[string]string, dest map[Locale]map[string]string, local
 	loc, ok := dest[locale]
 
 	if !ok {
-		loc = make(map[string]string)
+		loc = make(map[string]string, len(src))
 		dest[locale] = loc
 	}
 
@@ -433,46 +433,54 @@ func ParseInLocation(layout, value string, loc *time.Location, locale Locale) (t
 	return time.ParseInLocation(layout, value, loc)
 }
 
-func GetShortDays(locale Locale) (arr []string) {
+func GetShortDays(locale Locale) []string {
 	days, ok := knownDaysShort[locale]
 	if !ok {
-		return
+		return nil
 	}
+
+	ret := make([]string, 0, len(days))
 	for _, day := range days {
-		arr = append(arr, day)
+		ret = append(ret, day)
 	}
-	return
+	return ret
 }
 
-func GetShortMonths(locale Locale) (arr []string) {
+func GetShortMonths(locale Locale) []string {
 	months, ok := knownMonthsShort[locale]
 	if !ok {
-		return
+		return nil
 	}
+
+	ret := make([]string, 0, len(months))
 	for _, month := range months {
-		arr = append(arr, month)
+		ret = append(ret, month)
 	}
-	return
+	return ret
 }
 
-func GetLongDays(locale Locale) (arr []string) {
+func GetLongDays(locale Locale) []string {
 	days, ok := knownDaysLong[locale]
 	if !ok {
-		return
+		return nil
 	}
+
+	ret := make([]string, 0, len(days))
 	for _, day := range days {
-		arr = append(arr, day)
+		ret = append(ret, day)
 	}
-	return
+	return ret
 }
 
-func GetLongMonths(locale Locale) (arr []string) {
+func GetLongMonths(locale Locale) []string {
 	months, ok := knownMonthsLong[locale]
 	if !ok {
-		return
+		return nil
 	}
+
+	ret := make([]string, 0, len(months))
 	for _, month := range months {
-		arr = append(arr, month)
+		ret = append(ret, month)
 	}
-	return
+	return ret
 }

--- a/monday_test.go
+++ b/monday_test.go
@@ -360,6 +360,19 @@ func TestFormat(t *testing.T) {
 	}
 }
 
+func BenchmarkFormat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, ts := range formatTests {
+			txt := Format(ts.date, ts.layout, ts.locale)
+
+			if txt != ts.expected {
+				b.Errorf("failed")
+				continue
+			}
+		}
+	}
+}
+
 func TestBadLocale(t *testing.T) {
 	txt := Format(time.Date(2013, 9, 3, 0, 0, 0, 0, time.UTC), "Mon Jan 2 2006", "aa_AA")
 	if txt != "Tue Sep 3 2013" {


### PR DESCRIPTION
The `monday` package is an incredibly useful utility for localizing dates. However, after profiling some code, I've found that `monday.Format` has shown up in some hot loops.  My investigation has found a few areas where it's possible to get a speedup with fairly minimal changes.

For instance, the `Format` function internally relies on string concatenation rather than making use of `strings.Builder` or `bytes.Buffer`; this means that the formatting loops will allocate more often than they would otherwise need to. Additionally, specifying the slice and map capacity has improved performance in a few places, since they similarly require that the slice or map allocate backing arrays, reallocate them, and so forth.

Here are the results of running the new `BenchmarkFormat` method on `master` (labelled old) and my branch (labelled new):

```
name      old time/op    new time/op    delta
Format-8    2.44ms ±11%    2.03ms ±12%  -16.99%  (p=0.000 n=10+9)

name      old alloc/op   new alloc/op   delta
Format-8     665kB ± 0%     593kB ± 0%  -10.82%  (p=0.000 n=10+9)

name      old allocs/op  new allocs/op  delta
Format-8     23.6k ± 0%     20.0k ± 0%  -15.05%  (p=0.000 n=10+8)
```

This is a fairly noticeable decrease in allocations and time taken. Note:  I did not add benchmarks for all of the functions, just `Format`. However, functions like `GetLongDays` will be _much_ faster, improving more than `Format` did.