### PR TITLE
Address most feedback from the go lint tool

### DIFF
--- a/automation_test.go
+++ b/automation_test.go
@@ -13,7 +13,7 @@ type layoutData struct {
 }
 
 var (
-	testingLayoutsData []layoutData = []layoutData{
+	testingLayoutsData = []layoutData{
 		layoutData{
 			layout: "Mon, 2 Jan 2006 15:4:5 -0700",
 			matches: []string{
@@ -94,7 +94,7 @@ func TestLayoutValidator(t *testing.T) {
 			} else {
 				t.Logf("'%s' matches to '%s'..OK\n", m, ltd.layout)
 			}
-			var locale Locale = ld.detectLocale(m)
+			locale := ld.detectLocale(m)
 			if !compareLocales(locale, ltd.locales[i]) {
 				t.Errorf("locales detect error, expected '%s', result '%s'\n", ltd.locales[i], locale)
 			} else {

--- a/default_formats.go
+++ b/default_formats.go
@@ -204,7 +204,8 @@ const (
 	DefaultFormatCsCZDateTime = "02/01/2006 15:04"
 )
 
-// 'Full' date formats for all supported locales
+// FullFormatsByLocale maps locales to the'full' date formats for all
+// supported locales.
 var FullFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSFull,
 	LocaleEnGB: DefaultFormatEnGBFull,
@@ -241,7 +242,8 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZFull,
 }
 
-// 'Long' date formats for all supported locales
+// LongFormatsByLocale maps locales to the 'long' date formats for all
+// supported locales.
 var LongFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSLong,
 	LocaleEnGB: DefaultFormatEnGBLong,
@@ -278,7 +280,8 @@ var LongFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZLong,
 }
 
-// 'Medium' date formats for all supported locales
+// MediumFormatsByLocale maps locales to the 'medium' date formats for all
+// supported locales.
 var MediumFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSMedium,
 	LocaleEnGB: DefaultFormatEnGBMedium,
@@ -315,7 +318,8 @@ var MediumFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZMedium,
 }
 
-// 'Short' date formats for all supported locales
+// ShortFormatsByLocale maps locales to the 'short' date formats for all
+// supported locales.
 var ShortFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSShort,
 	LocaleEnGB: DefaultFormatEnGBShort,
@@ -352,7 +356,8 @@ var ShortFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZShort,
 }
 
-// 'DateTime' date formats for all supported locales
+// DateTimeFormatsByLocale maps locales to the 'DateTime' date formats for
+// all supported locales.
 var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSDateTime,
 	LocaleEnGB: DefaultFormatEnGBDateTime,

--- a/locale.go
+++ b/locale.go
@@ -4,6 +4,8 @@ package monday
 // Monday uses ICU locale identifiers. See http://userguide.icu-project.org/locale
 type Locale string
 
+// Locale constants represent all locales that are currently supported by
+// this package.
 const (
 	LocaleEnUS = "en_US" // English (United States)
 	LocaleEnGB = "en_GB" // English (United Kingdom)

--- a/monday.go
+++ b/monday.go
@@ -433,6 +433,12 @@ func ParseInLocation(layout, value string, loc *time.Location, locale Locale) (t
 	return time.ParseInLocation(layout, value, loc)
 }
 
+// GetShortDays retrieves the list of days for the given locale.
+// "Short" days are abbreviated versions of the full day names. In English,
+// for example, this might return "Tues" for "Tuesday". For certain locales,
+// the long and short form of the days of the week may be the same.
+//
+// If the locale cannot be found, the resulting slice will be nil.
 func GetShortDays(locale Locale) []string {
 	days, ok := knownDaysShort[locale]
 	if !ok {
@@ -446,6 +452,12 @@ func GetShortDays(locale Locale) []string {
 	return ret
 }
 
+// GetShortMonths retrieves the list of months for the given locale.
+// "Short" months are abbreviated versions of the full month names. In
+// English, for example, this might return "Jan" for "January". For
+// certain locales, the long and short form of the months may be the same.
+//
+// If the locale cannot be found, the resulting slice will be nil.
 func GetShortMonths(locale Locale) []string {
 	months, ok := knownMonthsShort[locale]
 	if !ok {
@@ -459,6 +471,10 @@ func GetShortMonths(locale Locale) []string {
 	return ret
 }
 
+// GetLongDays retrieves the list of days for the given locale. It will return
+// the full name of the days of the week.
+//
+// If the locale cannot be found, the resulting slice will be nil.
 func GetLongDays(locale Locale) []string {
 	days, ok := knownDaysLong[locale]
 	if !ok {
@@ -472,6 +488,11 @@ func GetLongDays(locale Locale) []string {
 	return ret
 }
 
+// GetLongMonths retrieves the list of months for the given locale. In
+// contrast to the "short" version of this function, this functions returns
+// the full name of the month.
+//
+// If the locale cannot be found, the resulting slice will be nil.
 func GetLongMonths(locale Locale) []string {
 	months, ok := knownMonthsLong[locale]
 	if !ok {


### PR DESCRIPTION
Go lint is a useful tool for improving the maintainability of a codebase. While it gets it wrong sometimes, its suggestions can be quite helpful.

For instance, it recommended reducing the nesting in some functions where the function already has returned, such as in `delimiterSpan.scanString()`. In other cases, it pushes for convention by making us drop receiver names such as `this` or `self`.

For the constants related to the locales, go lint will still complain after this PR. I have intentionally not renamed them for a few reasons:

1. It would break backwards compatibility to rename the exported constant `LocaleIdID` to `LocaleIDID` for no benefits to external users of the library.
2. A locale name ending in `IDID` is pretty hard to read.
3. Keeping the unexported internal constants using the same convention (`IdID`) makes it easier to follow the code.

Test results:

```
zstewart@hostname:ztstewart/monday ‹zts/go-lint*›$ go test -race ./...
ok      github.com/ztstewart/monday     1.187s
```