### PR TITLE
Use strings.Replacer for a large efficiency gain

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,4 @@ Thanks
 * [Luis Azevedo](https://github.com/braceta)
 * [imikod](https://github.com/imikod)
 * [Renato Serra](https://github.com/RenatoSerra22)
+* [Zachary Stewart](https://github.com/ztstewart)

--- a/automation_test.go
+++ b/automation_test.go
@@ -13,7 +13,7 @@ type layoutData struct {
 }
 
 var (
-	testingLayoutsData []layoutData = []layoutData{
+	testingLayoutsData = []layoutData{
 		layoutData{
 			layout: "Mon, 2 Jan 2006 15:4:5 -0700",
 			matches: []string{
@@ -94,7 +94,7 @@ func TestLayoutValidator(t *testing.T) {
 			} else {
 				t.Logf("'%s' matches to '%s'..OK\n", m, ltd.layout)
 			}
-			var locale Locale = ld.detectLocale(m)
+			locale := ld.detectLocale(m)
 			if !compareLocales(locale, ltd.locales[i]) {
 				t.Errorf("locales detect error, expected '%s', result '%s'\n", ltd.locales[i], locale)
 			} else {

--- a/default_formats.go
+++ b/default_formats.go
@@ -204,7 +204,8 @@ const (
 	DefaultFormatCsCZDateTime = "02/01/2006 15:04"
 )
 
-// 'Full' date formats for all supported locales
+// FullFormatsByLocale maps locales to the'full' date formats for all
+// supported locales.
 var FullFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSFull,
 	LocaleEnGB: DefaultFormatEnGBFull,
@@ -241,7 +242,8 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZFull,
 }
 
-// 'Long' date formats for all supported locales
+// LongFormatsByLocale maps locales to the 'long' date formats for all
+// supported locales.
 var LongFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSLong,
 	LocaleEnGB: DefaultFormatEnGBLong,
@@ -278,7 +280,8 @@ var LongFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZLong,
 }
 
-// 'Medium' date formats for all supported locales
+// MediumFormatsByLocale maps locales to the 'medium' date formats for all
+// supported locales.
 var MediumFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSMedium,
 	LocaleEnGB: DefaultFormatEnGBMedium,
@@ -315,7 +318,8 @@ var MediumFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZMedium,
 }
 
-// 'Short' date formats for all supported locales
+// ShortFormatsByLocale maps locales to the 'short' date formats for all
+// supported locales.
 var ShortFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSShort,
 	LocaleEnGB: DefaultFormatEnGBShort,
@@ -352,7 +356,8 @@ var ShortFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZShort,
 }
 
-// 'DateTime' date formats for all supported locales
+// DateTimeFormatsByLocale maps locales to the 'DateTime' date formats for
+// all supported locales.
 var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleEnUS: DefaultFormatEnUSDateTime,
 	LocaleEnGB: DefaultFormatEnGBDateTime,

--- a/format_ja_jp.go
+++ b/format_ja_jp.go
@@ -77,7 +77,7 @@ func parseFuncJaCommon(locale Locale) internalParseFunc {
 			value = strings.Replace(value, k, v, -1)
 		}
 
-		value = commonFormatFunc(value, layout,
+		value = commonParseFunc(value, layout,
 			knownDaysShortReverse[locale], knownDaysLongReverse[locale],
 			knownMonthsShortReverse[locale], knownMonthsLongReverse[locale], knownPeriods[locale])
 

--- a/format_pt_pt.go
+++ b/format_pt_pt.go
@@ -65,7 +65,7 @@ func parseFuncPtCommon(locale Locale) internalParseFunc {
 			value = strings.Replace(value, k, v, -1)
 		}
 
-		return commonFormatFunc(value, layout,
+		return commonParseFunc(value, layout,
 			knownDaysShortReverse[locale], knownDaysLongReverse[locale],
 			knownMonthsShortReverse[locale], knownMonthsLongReverse[locale], knownPeriods[locale])
 	}

--- a/format_zh_cn.go
+++ b/format_zh_cn.go
@@ -68,7 +68,7 @@ func parseFuncZhCommon(locale Locale) internalParseFunc {
 			value = strings.Replace(value, k, v, -1)
 		}
 
-		return commonFormatFunc(value, layout,
+		return commonParseFunc(value, layout,
 			knownDaysShortReverse[locale], knownDaysLongReverse[locale],
 			knownMonthsShortReverse[locale], knownMonthsLongReverse[locale], knownPeriods[locale])
 	}

--- a/locale.go
+++ b/locale.go
@@ -4,6 +4,8 @@ package monday
 // Monday uses ICU locale identifiers. See http://userguide.icu-project.org/locale
 type Locale string
 
+// Locale constants represent all locales that are currently supported by
+// this package.
 const (
 	LocaleEnUS = "en_US" // English (United States)
 	LocaleEnGB = "en_GB" // English (United Kingdom)

--- a/monday.go
+++ b/monday.go
@@ -2,6 +2,7 @@ package monday
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -106,6 +107,16 @@ var knownMonthsShortReverse = map[Locale]map[string]string{}         // Mapping 
 var knownMonthsGenitiveShortReverse = map[Locale]map[string]string{} // Mapping for 'Format', special for names in genitive, short form
 var knownMonthsGenitiveLongReverse = map[Locale]map[string]string{}  // Mapping for 'Format', special for names in genitive, long form
 var knownPeriodsReverse = map[Locale]map[string]string{}
+
+// Replacer maps; caches locale-specific strings.Replacer instances for fast
+// string formatting operations.
+var replacerDaysShort = map[Locale]*strings.Replacer{}           // Replacer for 'Format', days of week, short form
+var replacerDaysLong = map[Locale]*strings.Replacer{}            // Replacer for 'Format', days of week, long form
+var replacerMonthsLong = map[Locale]*strings.Replacer{}          // Replacer for 'Format', months: long form
+var replacerMonthsShort = map[Locale]*strings.Replacer{}         // Replacer for 'Format', months: short form
+var replacerMonthsGenitiveShort = map[Locale]*strings.Replacer{} // Replacer for 'Format', special for names in genitive, short form
+var replacerMonthsGenitiveLong = map[Locale]*strings.Replacer{}  // Replacer for 'Format', special for names in genitive, long form
+var replacerPeriods = map[Locale]*strings.Replacer{}
 
 func init() {
 	fillKnownWords()
@@ -364,6 +375,15 @@ func fillReverse(src map[string]string, dest map[Locale]map[string]string, local
 	}
 }
 
+func fillReplacer(src map[string]string, dest map[Locale]*strings.Replacer, locale Locale) {
+	toBeReplaced := make([]string, 0, len(src)*2)
+	for origStr, newStr := range src {
+		toBeReplaced = append(toBeReplaced, origStr, newStr)
+	}
+
+	dest[locale] = strings.NewReplacer(toBeReplaced...)
+}
+
 func fillKnownMonthsGenitiveShort(src map[string]string, locale Locale) {
 	fillReverse(src, knownMonthsGenitiveShortReverse, locale)
 	fill(src, knownMonthsGenitiveShort, locale)
@@ -377,26 +397,32 @@ func fillKnownMonthsGenitiveLong(src map[string]string, locale Locale) {
 func fillKnownDaysShort(src map[string]string, locale Locale) {
 	fillReverse(src, knownDaysShortReverse, locale)
 	fill(src, knownDaysShort, locale)
+	fillReplacer(src, replacerDaysShort, locale)
 }
 
 func fillKnownDaysLong(src map[string]string, locale Locale) {
 	fillReverse(src, knownDaysLongReverse, locale)
 	fill(src, knownDaysLong, locale)
+	fillReplacer(src, replacerDaysLong, locale)
 }
 
 func fillKnownMonthsShort(src map[string]string, locale Locale) {
 	fillReverse(src, knownMonthsShortReverse, locale)
 	fill(src, knownMonthsShort, locale)
+	fillReplacer(src, replacerMonthsShort, locale)
 }
 
 func fillKnownMonthsLong(src map[string]string, locale Locale) {
 	fillReverse(src, knownMonthsLongReverse, locale)
 	fill(src, knownMonthsLong, locale)
+	fillReplacer(src, replacerMonthsLong, locale)
 }
 
 func fillKnownPeriods(src map[string]string, locale Locale) {
 	fillReverse(src, knownPeriodsReverse, locale)
 	fill(src, knownPeriods, locale)
+	fillReplacer(src, replacerPeriods, locale)
+
 }
 
 // Format is the standard time.Format wrapper, that replaces known standard 'time' package

--- a/monday.go
+++ b/monday.go
@@ -433,6 +433,12 @@ func ParseInLocation(layout, value string, loc *time.Location, locale Locale) (t
 	return time.ParseInLocation(layout, value, loc)
 }
 
+// GetShortDays retrieves the list of days for the given locale.
+// "Short" days are abbreviated versions of the full day names. In English,
+// for example, this might return "Tues" for "Tuesday". For certain locales,
+// the long and short form of the days of the week may be the same.
+//
+// If the locale cannot be found, the resulting slice will be nil.
 func GetShortDays(locale Locale) []string {
 	days, ok := knownDaysShort[locale]
 	if !ok {
@@ -446,6 +452,12 @@ func GetShortDays(locale Locale) []string {
 	return ret
 }
 
+// GetShortMonths retrieves the list of months for the given locale.
+// "Short" months are abbreviated versions of the full month names. In
+// English, for example, this might return "Jan" for "January". For
+// certain locales, the long and short form of the months may be the same.
+//
+// If the locale cannot be found, the resulting slice will be nil.
 func GetShortMonths(locale Locale) []string {
 	months, ok := knownMonthsShort[locale]
 	if !ok {
@@ -459,6 +471,10 @@ func GetShortMonths(locale Locale) []string {
 	return ret
 }
 
+// GetLongDays retrieves the list of days for the given locale. It will return
+// the full name of the days of the week.
+//
+// If the locale cannot be found, the resulting slice will be nil.
 func GetLongDays(locale Locale) []string {
 	days, ok := knownDaysLong[locale]
 	if !ok {
@@ -472,6 +488,11 @@ func GetLongDays(locale Locale) []string {
 	return ret
 }
 
+// GetLongMonths retrieves the list of months for the given locale. In
+// contrast to the "short" version of this function, this functions returns
+// the full name of the month.
+//
+// If the locale cannot be found, the resulting slice will be nil.
 func GetLongMonths(locale Locale) []string {
 	months, ok := knownMonthsLong[locale]
 	if !ok {


### PR DESCRIPTION
By using strings.Replacer, we can drastically reduce the number of allocations and increase performance in Format for non-genitive languages. For these languages, formatting is more-or-less just a find and replace operation, so this change has a huge impact.

Benchstat shows the following results:

```
name      old time/op    new time/op    delta
Format-8    2.03ms ±12%    0.39ms ± 4%  -80.94%  (p=0.000 n=9+9)

name      old alloc/op   new alloc/op   delta
Format-8     593kB ± 0%      93kB ± 0%  -84.35%  (p=0.000 n=9+10)

name      old allocs/op  new allocs/op  delta
Format-8     20.0k ± 0%      2.7k ± 0%  -86.44%  (p=0.002 n=8+10)
```

That's a pretty big increase in performance. It undersells the gain too; the benchmark includes a wide variety of languages. 

While the genitive languages and parsing functions can still be improved by a good margin, the common formatting case is mostly optimized. Though it's possible to take it a step further. 

For example, strings.Replacer works on strings and thus copies the string once per case; if we had a bytes.Replacer equivalent and used []byte internally, that could be faster. We could then add an `AppendFormat` function to reduce allocations to zero for those who want it.