### PR TITLE
Order output for Get*Months Get*Days

### DIFF
--- a/default_orders.go
+++ b/default_orders.go
@@ -1,0 +1,71 @@
+package monday
+
+var dayLongOrderMondayFirst = []string{
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+	"Sunday",
+}
+
+var dayLongOrderSundayFirst = []string{
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+}
+
+var dayShortOrderMondayFirst = []string{
+	"Mon",
+	"Tue",
+	"Wed",
+	"Thu",
+	"Fri",
+	"Sat",
+	"Sun",
+}
+
+var dayShortOrderSundayFirst = []string{
+	"Sun",
+	"Mon",
+	"Tue",
+	"Wed",
+	"Thu",
+	"Fri",
+	"Sat",
+}
+
+var monthLongOrder = []string{
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December",
+}
+
+var monthShortOrder = []string{
+	"Jan",
+	"Feb",
+	"Mar",
+	"Apr",
+	"May",
+	"Jun",
+	"Jul",
+	"Aug",
+	"Sep",
+	"Oct",
+	"Nov",
+	"Dec",
+}

--- a/format_en_gb.go
+++ b/format_en_gb.go
@@ -1,0 +1,55 @@
+package monday
+
+// ============================================================
+// Format rules for "en_GB" locale: English (Great Britain)
+// ============================================================
+
+var longDayNamesEnGB = map[string]string{
+	"Sunday":    "Sunday",
+	"Monday":    "Monday",
+	"Tuesday":   "Tuesday",
+	"Wednesday": "Wednesday",
+	"Thursday":  "Thursday",
+	"Friday":    "Friday",
+	"Saturday":  "Saturday",
+}
+
+var shortDayNamesEnGB = map[string]string{
+	"Sun": "Sun",
+	"Mon": "Mon",
+	"Tue": "Tue",
+	"Wed": "Wed",
+	"Thu": "Thu",
+	"Fri": "Fri",
+	"Sat": "Sat",
+}
+
+var longMonthNamesEnGB = map[string]string{
+	"January":   "January",
+	"February":  "February",
+	"March":     "March",
+	"April":     "April",
+	"May":       "May",
+	"June":      "June",
+	"July":      "July",
+	"August":    "August",
+	"September": "September",
+	"October":   "October",
+	"November":  "November",
+	"December":  "December",
+}
+
+var shortMonthNamesEnGB = map[string]string{
+	"Jan": "Jan",
+	"Feb": "Feb",
+	"Mar": "Mar",
+	"Apr": "Apr",
+	"May": "May",
+	"Jun": "Jun",
+	"Jul": "Jul",
+	"Aug": "Aug",
+	"Sep": "Sep",
+	"Oct": "Oct",
+	"Nov": "Nov",
+	"Dec": "Dec",
+}

--- a/monday.go
+++ b/monday.go
@@ -97,7 +97,7 @@ var knownMonthsLong = map[Locale]map[string]string{}          // Mapping for 'Fo
 var knownMonthsShort = map[Locale]map[string]string{}         // Mapping for 'Format', months: short form
 var knownMonthsGenitiveShort = map[Locale]map[string]string{} // Mapping for 'Format', special for names in genitive, short form
 var knownMonthsGenitiveLong = map[Locale]map[string]string{}  // Mapping for 'Format', special for names in genitive, long form
-var knownPeriods = map[Locale]map[string]string{}			  // Mapping for 'Format', AM/PM
+var knownPeriods = map[Locale]map[string]string{}             // Mapping for 'Format', AM/PM
 
 // Reverse maps for the same
 
@@ -468,9 +468,20 @@ func GetShortDays(locale Locale) []string {
 		return nil
 	}
 
+	var dayOrder []string
+
+	// according to https://www.timeanddate.com/calendar/days/monday.html
+	// only Canada, USA and Japan use Sunday as first day of the week
+	switch locale {
+	case LocaleEnUS, LocaleJaJP:
+		dayOrder = dayShortOrderSundayFirst
+	default:
+		dayOrder = dayShortOrderMondayFirst
+	}
+
 	ret := make([]string, 0, len(days))
-	for _, day := range days {
-		ret = append(ret, day)
+	for _, day := range dayOrder {
+		ret = append(ret, days[day])
 	}
 	return ret
 }
@@ -488,8 +499,8 @@ func GetShortMonths(locale Locale) []string {
 	}
 
 	ret := make([]string, 0, len(months))
-	for _, month := range months {
-		ret = append(ret, month)
+	for _, m := range monthShortOrder {
+		ret = append(ret, months[m])
 	}
 	return ret
 }
@@ -504,9 +515,20 @@ func GetLongDays(locale Locale) []string {
 		return nil
 	}
 
+	var dayOrder []string
+
+	// according to https://www.timeanddate.com/calendar/days/monday.html
+	// only Canada, USA and Japan use Sunday as first day of the week
+	switch locale {
+	case LocaleEnUS, LocaleJaJP:
+		dayOrder = dayLongOrderSundayFirst
+	default:
+		dayOrder = dayLongOrderMondayFirst
+	}
+
 	ret := make([]string, 0, len(days))
-	for _, day := range days {
-		ret = append(ret, day)
+	for _, day := range dayOrder {
+		ret = append(ret, days[day])
 	}
 	return ret
 }
@@ -523,8 +545,9 @@ func GetLongMonths(locale Locale) []string {
 	}
 
 	ret := make([]string, 0, len(months))
-	for _, month := range months {
-		ret = append(ret, month)
+	for _, m := range monthLongOrder {
+		ret = append(ret, months[m])
 	}
+
 	return ret
 }

--- a/monday_test.go
+++ b/monday_test.go
@@ -397,8 +397,27 @@ func TestBadLocale(t *testing.T) {
 func TestGetShortDays(t *testing.T) {
 	locales := ListLocales()
 	for _, locale := range locales {
-		if days := GetShortDays(locale); days == nil {
+		days := GetShortDays(locale)
+		if days == nil {
 			t.Error("Not expected result. ", days)
+		}
+
+		// according to https://www.timeanddate.com/calendar/days/monday.html
+		// only Canada, USA and Japan use Sunday as first day of the week
+		switch locale {
+		case LocaleEnUS:
+			if days[0] != shortDayNamesEnUS["Sun"] {
+				t.Error("first day of week in US should be Sunday", days)
+			}
+		case LocaleJaJP:
+			if days[0] != shortDayNamesJaJP["Sun"] {
+				t.Error("first day of week in JP should be Sunday", days)
+			}
+
+		default:
+			if days[0] != knownDaysShort[locale]["Mon"] {
+				t.Error("first day of week should be Monday", days, locale)
+			}
 		}
 	}
 }
@@ -406,8 +425,27 @@ func TestGetShortDays(t *testing.T) {
 func TestGetLongDays(t *testing.T) {
 	locales := ListLocales()
 	for _, locale := range locales {
-		if days := GetLongDays(locale); days == nil {
+		days := GetLongDays(locale)
+		if days == nil {
 			t.Error("Not expected result. ", days)
+		}
+
+		// according to https://www.timeanddate.com/calendar/days/monday.html
+		// only Canada, USA and Japan use Sunday as first day of the week
+		switch locale {
+		case LocaleEnUS:
+			if days[0] != longDayNamesEnUS["Sunday"] {
+				t.Error("first day of week in US should be Sunday", days)
+			}
+		case LocaleJaJP:
+			if days[0] != longDayNamesJaJP["Sunday"] {
+				t.Error("first day of week in JP should be Sunday", days)
+			}
+
+		default:
+			if days[0] != knownDaysLong[locale]["Monday"] {
+				t.Error("first day of week should be Monday", days, locale)
+			}
 		}
 	}
 }

--- a/monday_test.go
+++ b/monday_test.go
@@ -398,7 +398,7 @@ func TestGetShortDays(t *testing.T) {
 	locales := ListLocales()
 	for _, locale := range locales {
 		days := GetShortDays(locale)
-		if days == nil {
+		if days == nil || len(days) != 7 {
 			t.Error("Not expected result. ", days)
 		}
 
@@ -426,7 +426,7 @@ func TestGetLongDays(t *testing.T) {
 	locales := ListLocales()
 	for _, locale := range locales {
 		days := GetLongDays(locale)
-		if days == nil {
+		if days == nil || len(days) != 7 {
 			t.Error("Not expected result. ", days)
 		}
 


### PR DESCRIPTION
I have some use cases where I do not have an actual time.Time, but only need the list of months in a given locale. `GetLongMonths` etc. seem to want to give me exactly that, but they aren't ordered. 

I see that as a bug, hence this PR. 

As far as I see only the USA, Canada and Japan see sunday as first day of the week. So I think it is sufficient to handle their speciality inside the getter function rather than introducing a new order variable in all locale files. 