### PR TITLE
Migrate to Go Modules + add tests in github workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+name: Go
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,4 +25,10 @@ jobs:
         fi
 
     - name: Build
-      run: go build -v .
+      run: |
+        go vet
+        go build -v .
+
+    - name: Test
+      run: go test -v -race monday
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,5 +30,5 @@ jobs:
         go build -v .
 
     - name: Test
-      run: go test -v -race monday
+      run: go test -v -race .
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+/monday.iml
+/.idea/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module monday
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module monday
+module github.com/bmarguer/monday
 
 go 1.13


### PR DESCRIPTION
* go.mod : module name should be replaced from github.com/bmarguer/monday to github.com/goodsign/monday
* github workflow: play automatically tests in race mode and linter
* if you could add a version with pattern v1.0.0 to be support by go mod, It would be perfect.