### PR TITLE
Minor text error correction

### DIFF
--- a/automation.go
+++ b/automation.go
@@ -313,7 +313,7 @@ func (ld *LocaleDetector) Parse(layout, value string) (time.Time, error) {
 	return time.Time{}, &time.ParseError{
 		Value:   value,
 		Layout:  layout,
-		Message: fmt.Sprintf("'%s' not matches to '%s' last error position = %d\n", value, layout, ld.lastErrorPosition),
+		Message: fmt.Sprintf(" doesn't match '%s' last error position = %d\n", value, layout, ld.lastErrorPosition),
 	}
 }
 


### PR DESCRIPTION
If you provide a message, time.ParseError puts a quoted version of the text already here:

https://github.com/golang/go/blob/55044288ad22f0c46ac55375ed9ef3de1babb77c/src/time/format.go#L894-L895