### PR TITLE
Fixed issue with date time I was having - added it as a test too

### DIFF
--- a/debug_off.go
+++ b/debug_off.go
@@ -1,0 +1,8 @@
+//go:build !debug
+// +build !debug
+
+package monday
+
+const (
+	debugLayoutDef = false
+)

--- a/debug_on.go
+++ b/debug_on.go
@@ -1,0 +1,14 @@
+//go:build debug
+// +build debug
+
+package monday
+
+import "log"
+
+const (
+	debugLayoutDef = on
+)
+
+func init() {
+	log.SetFlags(log.Flags() | log.Lshortfile)
+}


### PR DESCRIPTION
As the commit says:

> Fixed issue with date time I was having - added it as a test too, added sub tests for filtering and identificatin purposes, switched to logging library for logs (adds new line, and date time + line numbers) Added build tags for debug mode (see https://www.digitalocean.com/community/tutorials/customizing-go-binaries-with-build-tags)

I have gone a bit far with this. Let me know if you want me to break it up or remove / explain things.

As I said in https://github.com/goodsign/monday/issues/58 I'm not quite sure the `text.Scanner` is the right way of doing this but I was able to work with it. (It has consequences.)