### PR TITLE
fix: updated August short month name for id_ID locale

### DIFF
--- a/format_id_id.go
+++ b/format_id_id.go
@@ -47,7 +47,7 @@ var shortMonthNamesIdID = map[string]string{
 	"May": "Mei",
 	"Jun": "Jun",
 	"Jul": "Jul",
-	"Aug": "Ags",
+	"Aug": "Agu",
 	"Sep": "Sep",
 	"Oct": "Okt",
 	"Nov": "Nov",


### PR DESCRIPTION
The August short month name in the Indonesian locale was initially set to be "**Ags**". But it was later shown that "**Agu**" was the preferrable abbreviation, as explained by an Indonesian linguist (_ref 1._) and as shown on Wikipedia (_ref 2._).

ref:
1. https://twitter.com/ivanlanin/status/1298795394562846723
2. https://id.wikipedia.org/wiki/Bulan_(penanggalan)